### PR TITLE
Fix `ons_deaths` table update

### DIFF
--- a/analysis/databuilder_definition.py
+++ b/analysis/databuilder_definition.py
@@ -118,26 +118,23 @@ dataset.msoa = address_as_of(study_start_date).msoa_code
 dataset.imd = address_as_of(study_start_date).imd_rounded
 dataset.death_date = patients.date_of_death
 
-# First registered death for patient
-dataset.ons_death_date = ons_deaths.date
-dataset.ons_underlying_cause = ons_deaths.underlying_cause_of_death
-# dataset.ons_covid_on_deathcert = (
-#     covid_on_deathcert(ons_deaths.cause_of_death_01) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_02) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_03) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_04) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_05) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_06) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_07) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_08) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_09) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_10) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_11) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_12) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_13) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_14) +
-#     covid_on_deathcert(ons_deaths.cause_of_death_15)
-# )
+# Date and underlying cause of earliest registered death for patients
+# where registered death date >= pt_start_date and < pt_end_date
+dataset.ons_death_date = case(
+    when(
+        (ons_deaths.date >= dataset.pt_start_date)
+        & (ons_deaths.date < dataset.pt_end_date)
+    ).then(ons_deaths.date),
+    default=None,
+)
+
+dataset.ons_underlying_cause = case(
+    when(
+        (ons_deaths.date >= dataset.pt_start_date)
+        & (ons_deaths.date < dataset.pt_end_date)
+    ).then(ons_deaths.underlying_cause_of_death),
+    default=None,
+)
 
 # Ethnicity in 6 categories ------------------------------------------------------------
 dataset.ethnicity = clinical_events.where(clinical_events.ctv3_code.is_in(codelists.ethnicity)) \


### PR DESCRIPTION
This suggestion fixes part of the translation I missed in #20 and now matches the intended behaviour of the earlier dataset definition. Only dates and underlying causes that fall within `pt_start_date` and `pt_end_date` are included in the dataset, otherwise `NULL` is returned.

I'm also deleting a comment because it would not work anymore without applying the same `case().when().then()` logic.